### PR TITLE
Feat:

### DIFF
--- a/src/app/api/tickets/answer/[ticketId]/route.ts
+++ b/src/app/api/tickets/answer/[ticketId]/route.ts
@@ -1,0 +1,51 @@
+import dbConnection from "@/dbConfigs/db";
+import TicketModel from "@/models/tickets/ticket";
+import { MessagesType } from "@/types/models/ticket.type";
+import { getUser } from "@/utils/auth/authHelper";
+import { isValidObjectId } from "mongoose";
+import { Params } from "next/dist/shared/lib/router/utils/route-matcher";
+import { notFound } from "next/navigation";
+
+export const POST = async (req: Request, { params }: Params) => {
+  try {
+    await dbConnection();
+    const user = await getUser();
+    if (user.role !== "ADMIN") {
+      return Response.json(
+        { message: "شما به این قسمت دسترسی ندارید." },
+        { status: 404 }
+      );
+    }
+    const { ticketId } = params;
+    if (!isValidObjectId(ticketId)) return notFound();
+    const reqBody = await req.json();
+    const { body, sendAt, sender }: MessagesType = reqBody;
+    if (!sender || !body.trim()) {
+      return Response.json(
+        { message: "پاسخ ارسالی نامعتبر است" },
+        { status: 400 }
+      );
+    }
+    const ticket = await TicketModel.findById(ticketId);
+    if (!ticket) return notFound();
+    ticket.adminMessages.push({
+      sender,
+      body,
+      sendAt: new Date(),
+    });
+    await TicketModel.findOneAndUpdate(
+      { _id: ticketId },
+      { $set: { isAnswered: true, isPending: false } }
+    );
+    await ticket.save();
+    return Response.json(
+      { message: "پاسخ شما برای کاربر ارسال گردید" },
+      { status: 201 }
+    );
+  } catch (error) {
+    return Response.json(
+      { message: `خطا سمت سرور =>`, error },
+      { status: 500 }
+    );
+  }
+};

--- a/src/app/my-account/tickets/all-user-tickets/[ticketId]/page.tsx
+++ b/src/app/my-account/tickets/all-user-tickets/[ticketId]/page.tsx
@@ -1,17 +1,19 @@
-import SingleTicket from '@/components/layout-components/UserPanelPage/subRoutes/SingleTicket';
+import TicketLayout from '@/components/layout-components/UserPanelPage/subRoutes/TicketLayout';
 import dbConnection from '@/dbConfigs/db';
 import TicketModel from '@/models/tickets/ticket';
 import dataParser from '@/utils/dataParser/dataParser';
 import { isValidObjectId } from 'mongoose';
 import { notFound } from 'next/navigation';
-async function page({params}:{params:{ticketId:string}}) {
-  const {ticketId} = params
+  async function page({params}:{params:{ticketId:string}}) {
     await dbConnection();
-   
+  const {ticketId} = params
     if(!isValidObjectId(ticketId)) return notFound();
-    const userTickets = await TicketModel.findOne({_id:ticketId},"-__v").populate("user","userName").lean();
+    const ticket = await TicketModel.findOne({ _id: ticketId }, "-__v")
+    .populate("messages.sender", "userName role").populate("adminMessages.sender","userName role")
+    .populate("user", "userName")
+    .lean();
   return (
-<SingleTicket ticketId={ticketId} initData={dataParser(userTickets)}/>
+<TicketLayout ticketId={ticketId} ticket={dataParser(ticket)}/>
   )
 }
 

--- a/src/components/layout-components/AdminPanel/subRoutes/Tickets/LargeTicketTRow.tsx
+++ b/src/components/layout-components/AdminPanel/subRoutes/Tickets/LargeTicketTRow.tsx
@@ -1,5 +1,6 @@
 import Table from "@/components/UI/Table/Table";
 import useRemoveTicket from "@/hooks/tickets&department/useRemoveTicket";
+import useUpdateTicketST from "@/hooks/tickets&department/useUpdateTicketST";
 import { TicketStatusType, TicketType } from "@/types/models/ticket.type";
 import { priorityValues, ticketOptions, ticketStatus } from "@/utils/constants";
 import { FormEvent, useState } from "react";
@@ -7,8 +8,10 @@ import { ImReply } from "react-icons/im";
 import { IoLockClosed } from "react-icons/io5";
 import { MdDelete } from "react-icons/md";
 import DeleteModal from "../modals/DeleteModal";
+import EditModal from "../modals/EditModal";
 import SelectModal from "../modals/SelectModal";
-import useUpdateTicketST from "@/hooks/tickets&department/useUpdateTicketST";
+import ReplyModal from "./ReplyModal";
+
 type LgTRowType = {
   ticket: TicketType;
   index: number;
@@ -16,7 +19,8 @@ type LgTRowType = {
 function LargeTicketTRow({ ticket, index }: LgTRowType) {
   const [isDeleteOpen, setIsDeleteOpen] = useState<boolean>(false);
   const [isSelectOpen, setIsSelectOpen] = useState<boolean>(false);
-  const [isOpenTicket, setIsOpenTicket] = useState<boolean>(ticket.isOpen) ;
+  const [isReplyOpen, setIsReplyOpen] = useState(false);
+  const [isOpenTicket, setIsOpenTicket] = useState<boolean>(ticket.isOpen);
   const { isRemoveLoading, removeTicket } = useRemoveTicket();
   const { isUpdateLoading, updateTicketSt } = useUpdateTicketST();
 
@@ -39,11 +43,11 @@ function LargeTicketTRow({ ticket, index }: LgTRowType) {
     e.preventDefault();
     try {
       if (ticket._id === undefined) return;
-        const updateTicketCondtion :TicketStatusType ={
-          isPending:false,
-          isAnswered:true,
-          isOpen:isOpenTicket
-        }
+      const updateTicketCondtion: TicketStatusType = {
+        isPending: false,
+        isAnswered: true,
+        isOpen: isOpenTicket,
+      };
       await updateTicketSt(
         { ticketId: ticket._id, data: updateTicketCondtion },
         {
@@ -55,7 +59,7 @@ function LargeTicketTRow({ ticket, index }: LgTRowType) {
           },
         }
       );
-    } catch (error:any) {
+    } catch (error: any) {
       console.log(error?.response?.data?.message);
     }
   };
@@ -101,7 +105,7 @@ function LargeTicketTRow({ ticket, index }: LgTRowType) {
       </td>
       <td className=" flex items-center gap-x-4">
         <button
-          // onClick={() => setIsReplyOpen(true)}
+          onClick={() => setIsReplyOpen(true)}
           className="text-2xl text-blue-500 mx-auto  w-fit flex justify-center "
         >
           <ImReply />
@@ -142,6 +146,17 @@ function LargeTicketTRow({ ticket, index }: LgTRowType) {
         subjectTitle="باز / بستن تیکت"
         options={ticketOptions}
       />
+     {ticket._id !== undefined &&
+      <EditModal
+      isOpen={isReplyOpen}
+      setIsOpen={() => setIsReplyOpen(false)}
+      modalTitle="پاسخ به تیکت"
+      className="!w-[100%] !h-auto  overflow-y-auto py-2 !top-[2%]"
+    >
+     <div className="h-full py-2">
+     <ReplyModal ticketId={ticket._id} />
+     </div>
+    </EditModal>}
     </Table.Row>
   );
 }

--- a/src/components/layout-components/AdminPanel/subRoutes/Tickets/ReplyModal.tsx
+++ b/src/components/layout-components/AdminPanel/subRoutes/Tickets/ReplyModal.tsx
@@ -1,0 +1,14 @@
+import SingleTicket from '@/components/layout-components/UserPanelPage/subRoutes/SingleTicket'
+import React from 'react'
+import ReplyForm from './ReplyForm'
+import { TicketType } from '@/types/models/ticket.type'
+
+function ReplyModal({ticketId}:{ticketId:string}) {
+  return (
+<SingleTicket ticketId={ticketId}>
+<ReplyForm ticketId={ticketId} />
+</SingleTicket>
+  )
+}
+
+export default ReplyModal

--- a/src/components/layout-components/AdminPanel/subRoutes/Tickets/SmallTicketTRow.tsx
+++ b/src/components/layout-components/AdminPanel/subRoutes/Tickets/SmallTicketTRow.tsx
@@ -9,6 +9,9 @@ import { MdDelete } from "react-icons/md";
 import DeleteModal from "../modals/DeleteModal";
 import useUpdateTicketST from "@/hooks/tickets&department/useUpdateTicketST";
 import SelectModal from "../modals/SelectModal";
+import EditModal from "../modals/EditModal";
+import ReplyModal from "./ReplyModal";
+import { useRouter } from "next/navigation";
 
 function SmallTicketTRow({ ticket }: { ticket: TicketType }) {
   const [isDeleteOpen, setIsDeleteOpen] = useState<boolean>(false);
@@ -16,12 +19,15 @@ function SmallTicketTRow({ ticket }: { ticket: TicketType }) {
   const [isSelectOpen, setIsSelectOpen] = useState<boolean>(false);
   const [isOpenTicket, setIsOpenTicket] = useState<boolean>(ticket.isOpen);
   const { isUpdateLoading, updateTicketSt } = useUpdateTicketST();
+  const {refresh} = useRouter();
+  const [isReplyOpen, setIsReplyOpen] = useState(false);
   const removeHandler = async () => {
     try {
       if (ticket._id === undefined) return;
       await removeTicket(ticket._id, {
         onSuccess: () => {
           setIsDeleteOpen(false);
+          refresh();
         },
         onError: () => {
           setIsDeleteOpen(false);
@@ -51,7 +57,7 @@ function SmallTicketTRow({ ticket }: { ticket: TicketType }) {
           },
         }
       );
-    } catch (error:any) {
+    } catch (error: any) {
       console.log(error?.response?.data?.message);
     }
   };
@@ -148,6 +154,18 @@ function SmallTicketTRow({ ticket }: { ticket: TicketType }) {
         subjectTitle="باز / بستن تیکت"
         options={ticketOptions}
       />
+      {ticket._id !== undefined && (
+        <EditModal
+          isOpen={isReplyOpen}
+          setIsOpen={() => setIsReplyOpen(false)}
+          modalTitle="پاسخ به تیکت"
+          className="!w-[100%] !h-auto  overflow-y-auto py-2 !top-[2%]"
+        >
+          <div className="h-full py-2">
+            <ReplyModal ticketId={ticket._id} />
+          </div>
+        </EditModal>
+      )}
     </Table.Row>
   );
 }

--- a/src/components/layout-components/UserPanelPage/subRoutes/SingleTicket.tsx
+++ b/src/components/layout-components/UserPanelPage/subRoutes/SingleTicket.tsx
@@ -1,30 +1,31 @@
 "use client";
 import Loader from "@/components/UI/loader/Loader";
+import useGetMe from "@/hooks/authHooks/useGetMe";
 import useGetTicketData from "@/hooks/tickets&department/useGetTicketData";
-import { MessagesType, TicketType } from "@/types/models/ticket.type";
-import ReplyFormHandler from "../ReplyFormHandler";
+import { ChildrenProps } from "@/types/global.type";
+import { MessagesType } from "@/types/models/ticket.type";
+import React from "react";
 
-function SingleTicket({
-  ticketId,
-  initData,
-}: {
-  ticketId: string;
-  initData: TicketType[];
-}) {
-  const { ticket, isTicketLoading } = useGetTicketData(ticketId, initData);
-
-  if (isTicketLoading)
+const  SingleTicket :React.FC<ChildrenProps&{ticketId:string}> =({ticketId,children}) => {
+  const { ticket, isTicketLoading } = useGetTicketData(ticketId);
+  const { user, isUserloading } = useGetMe();
+  if (isTicketLoading || isUserloading)
     return (
       <div className=" flex gap-x-2">
         <span>
-          <Loader loadingCondition={isTicketLoading} />
+          <Loader loadingCondition={isTicketLoading || isUserloading} />
         </span>
         <span>در حال بارگزاری ...</span>
       </div>
     );
+  const adminMsgs = ticket?.adminMessages || [];
+  const userMsgs = ticket?.messages || [];
+  const concatMsgs = [...adminMsgs, ...userMsgs].sort(
+    (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
+  );
   return (
-    <div className="relative w-full sm:px-4 h-full">
-      <div className=" rounded-lg bg-gray-200 h-full p-4">
+    <div className=" w-full sm:px-4 h-full">
+      <div className=" rounded-lg !relative bg-gray-200 !h-[550px] overflow-y-auto p-4">
         <div className="">
           <h1
             className="text-right font-Shabnam_B
@@ -33,9 +34,17 @@ function SingleTicket({
             {ticket?.title}
           </h1>
         </div>
-        {/* user ticket box */}
-        <div className="w-full !h-[510px] overflow-y-auto">
-          <div className="mt-4 p-4 flex flex-col shadow-sm text-gray-200 bg-gray-500  max-w-[60%] rounded-xl rounded-tr-none">
+        {/* chat box */}
+        <div className="w-full ">
+          <div
+            className={`
+            mt-4 p-4  flex flex-col shadow-sm text-gray-200   
+            xs:max-w-[90%] sm:max-w-[60%] rounded-xl 
+            ${
+              String(ticket?.user?._id) === String(user?._id)
+                ? `rounded-tr-none bg-gray-500 `
+                : `bg-slate-700 mr-auto rounded-tl-none`
+            }`}>
             <p className=" md:text-xl  text-right font-Shabnam_M w-fit">
               {ticket?.user?.userName}
             </p>
@@ -47,48 +56,39 @@ function SingleTicket({
             </p>
           </div>
           {/* reply box */}
-          {ticket?.messages.map((message: MessagesType) => (
-            <div
-              key={message._id}
-              className={`mt-4 p-4 flex flex-col shadow-sm text-gray-200 ${
-                message.sender === ticket.user._id
-                  ? "bg-gray-500 max-w-[60%] rounded-xl rounded-tr-none self-end"
-                  : "bg-slate-700 max-w-[60%] rounded-xl rounded-tl-none self-start"
-              }`}
-            >
-              <p className="md:text-xl text-right font-Shabnam_M w-fit">
-                {message.sender === ticket.user._id
-                  ? ticket.user.userName
-                  : "مدیر"}
-              </p>
-              <span className="w-fit mt-px text-base tx">
-                {new Date(message.sendAt).toLocaleDateString("fa-Ir")}
-              </span>
-              <p className="w-fit text-right mt-6 mr-2 font-Shabnam_M">
-                {message.body}
-              </p>
-            </div>
-          ))}
-
-          {/* answer box */}
-          <div className="mt-6 p-4 flex flex-col  mr-auto shadow-sm text-gray-200 bg-slate-700  max-w-[60%] rounded-xl rounded-tl-none">
-            <p className=" md:text-xl  text-left mr-auto font-Shabnam_M w-fit">
-              {ticket?.user?.userName}
-            </p>
-            <p className="w-fit  mt-px text-base  text-left mr-auto">
-              {new Date(ticket?.createdAt).toLocaleDateString("fa-Ir")}
-            </p>
-            <p className="w-fit text-right mt-6 mr-2 font-Shabnam_M">
-              با سلام و احترام... درخواست شما در دست بررسی است از شکیبایی شما
-              متشکریم.
-            </p>
-          </div>
+          {concatMsgs.length > 0 &&
+            concatMsgs.map((message: MessagesType, index: number) => {
+              const isOwnMessage =
+                String(message.sender._id) === String(user._id);
+              return (
+                <div
+                  key={index}
+                  className={`mt-4 p-4 flex  flex-col shadow-sm text-gray-200 
+                 xs:max-w-[90%] sm:max-w-[60%]  rounded-xl
+            ${
+              isOwnMessage
+                ? "bg-gray-500  rounded-tr-none"
+                : "bg-slate-700 mr-auto rounded-tl-none"
+            }`}
+                >
+                  <p className="md:text-xl text-right font-Shabnam_M w-fit">
+                    {message.sender.userName}
+                  </p>
+                  <span className="w-fit mt-px text-base tx">
+                    {new Date(message.sendAt).toLocaleDateString("fa-Ir")}
+                  </span>
+                  <p className="w-fit text-right mt-6 mr-2 font-Shabnam_M">
+                    {message.body}
+                  </p>
+                </div>
+              );
+            })}
         </div>
         {/* reply form */}
         {ticket?.isOpen ? (
-     <ReplyFormHandler ticketId={ticketId} ticket={ticket}/>
+          children
         ) : (
-          <div className="w-full py-2 px-2 text-center mx-auto  text-white bg-slate-900">
+          <div className="w-full  mt-2 py-2 px-2 text-center mx-auto  text-white bg-slate-900">
             <p>این تیکت بسته شده است</p>
           </div>
         )}

--- a/src/components/layout-components/UserPanelPage/subRoutes/TicketLayout.tsx
+++ b/src/components/layout-components/UserPanelPage/subRoutes/TicketLayout.tsx
@@ -1,0 +1,17 @@
+"use client"
+import React from 'react'
+import SingleTicket from './SingleTicket'
+import ReplyFormHandler from '../ReplyFormHandler'
+import { TicketType } from '@/types/models/ticket.type'
+
+function TicketLayout({ticketId,ticket}:{ticketId:string,ticket:TicketType}) {
+  return (
+    <>
+    <SingleTicket ticketId={ticketId} >
+    <ReplyFormHandler ticketId={ticketId} ticket={ticket} />
+    </SingleTicket>
+    </>
+  )
+}
+
+export default TicketLayout

--- a/src/hooks/authHooks/useLogout.ts
+++ b/src/hooks/authHooks/useLogout.ts
@@ -10,6 +10,7 @@ const useLogOut = () => {
     mutationFn: logOutUser,
     onSuccess: () => {
       router.replace("/")
+      router.refresh();
       queryClient.invalidateQueries({ queryKey: ["getMe"] });
       toast.success("خروج موفقیت آمیز");
     },

--- a/src/hooks/tickets&department/useGetTicketData.ts
+++ b/src/hooks/tickets&department/useGetTicketData.ts
@@ -1,12 +1,11 @@
 import { getSingleTicketData } from "@/services/tickets&departments/ticketServices";
-import { TicketType } from "@/types/models/ticket.type";
 import { useQuery } from "@tanstack/react-query";
 
-const useGetTicketData = (ticketId: string,initData:TicketType[]) => {
+const useGetTicketData = (ticketId: string) => {
   const { data: ticket, isPending: isTicketLoading } = useQuery({
     queryKey: ["ticket", ticketId],
     queryFn: () => getSingleTicketData(ticketId),
-    initialData:initData
+ 
   });
   return { ticket, isTicketLoading };
 };

--- a/src/hooks/tickets&department/useReplyAdminTicket.ts
+++ b/src/hooks/tickets&department/useReplyAdminTicket.ts
@@ -1,0 +1,20 @@
+import { replyAdminTicket } from "@/services/tickets&departments/ticketServices";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
+
+const useReplyAdminTicket = () => {
+  const queryClient = useQueryClient();
+  const { mutateAsync: replyAdmin, isPending: isReplyLoading } = useMutation({
+    mutationFn: replyAdminTicket,
+    onSuccess: (data: any) => {
+      toast.success(data?.message);
+      queryClient.invalidateQueries({ queryKey: ["allTickets"] });
+      queryClient.invalidateQueries({ queryKey: ["ticket"] });
+    },
+    onError: (err: any) => {
+      toast.error(err?.response?.data?.message);
+    },
+  });
+  return { replyAdmin, isReplyLoading };
+};
+export default useReplyAdminTicket;

--- a/src/hooks/tickets&department/useReplyTicketMsg.ts
+++ b/src/hooks/tickets&department/useReplyTicketMsg.ts
@@ -7,6 +7,7 @@ const useReplyTicketMsg =  () => {
     mutationFn:  ReplyTicketMsg,
     onSuccess: () => {
       QueryClient.invalidateQueries({ queryKey: ["ticket"] });
+      QueryClient.invalidateQueries({ queryKey: ["allTickets"] });
     },
   });
   return { SendReply, isSending };

--- a/src/hooks/tickets&department/useUpdateTicketST.ts
+++ b/src/hooks/tickets&department/useUpdateTicketST.ts
@@ -10,6 +10,7 @@ const useUpdateTicketST = () => {
       onSuccess(data: any) {
         toast.success(data.message);
         queryClient.invalidateQueries({ queryKey: ["allTickets"] });
+        queryClient.invalidateQueries({ queryKey: ["ticket"] });
       },
       onError(error: any) {
         toast.error(error?.response?.data?.message);

--- a/src/models/tickets/ticket.ts
+++ b/src/models/tickets/ticket.ts
@@ -42,6 +42,10 @@ const schema = new Schema<TicketType>(
       type: [messageSchema],
       default: [],
     },
+    adminMessages: {
+      type: [messageSchema],
+      default: [],
+    },
   },
 
   {

--- a/src/services/tickets&departments/ticketServices.ts
+++ b/src/services/tickets&departments/ticketServices.ts
@@ -1,15 +1,15 @@
-import { TicketStatusType } from "@/types/models/ticket.type";
+import { MessagesType, TicketStatusType } from "@/types/models/ticket.type";
 import api from "../httpServices";
 
 export const AddNewTicket = async (data:any) => {
   return  await api.post("/tickets", data).then((data) => data.data);
 };
 export const getSingleTicketData = async (ticketId:string) => {
-  return  await api.get(`/tickets/${ticketId}`).then(({data}) => data.data);
+  return  await api.get(`/tickets/${ticketId}`).then((response)=>response.data);
 };
 
 export const ReplyTicketMsg = async ({ticketId,data}:{ticketId:string,data:any})=>{
-  return await api.post(`/tickets/${ticketId}`,data).then(({data})=>data.data)
+  return await api.post(`/tickets/${ticketId}`,data).then(({data})=>console.log(data))
 }
 
 export const getAllTickets= async()=>{
@@ -25,4 +25,12 @@ try {
 } catch (error) {
   return null
 }
+}
+
+export const replyAdminTicket = async({ticketId,data}:{ticketId:string,data:MessagesType})=>{
+  try {
+ return api.post(`/tickets/answer/${ticketId}`,data).then(response=>response.data)    
+  } catch (error) {
+    return null
+  }
 }

--- a/src/types/models/ticket.type.ts
+++ b/src/types/models/ticket.type.ts
@@ -17,6 +17,7 @@ export type TicketType = {
   isPending: boolean;
   isAnswered: boolean;
   messages: MessagesType[];
+  adminMessages?:MessagesType[];
 };
 
 export type MessagesType = {


### PR DESCRIPTION
-Add reply admin ticket api
-Handle reply form modal for admin panel
-Add custom hook & type & req service for reply admin ticket -Add adminMessages section in ticket model

--------------------
Fix:
-Fix populate accurate data from single ticket api & init page -Add refresh prop to update ticket status after user action -Fix useLogout hook

-------------------
Refactor:
-Share singleTicket comp between admin & user panel with children prop -Split single Ticket in sub comp for sharing between two use role side -Remove initial data from single ticket hook for share comp